### PR TITLE
Add the timeout-factor parameter in browserperfdash-benchmark

### DIFF
--- a/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/webkitpy/benchmark_runner/benchmark_runner.py
@@ -23,7 +23,7 @@ _log = logging.getLogger(__name__)
 class BenchmarkRunner(object):
     name = 'benchmark_runner'
 
-    def __init__(self, plan_file, local_copy, count_override, build_dir, output_file, platform, browser, scale_unit=True, show_iteration_values=False, device_id=None):
+    def __init__(self, plan_file, local_copy, timeout_factor, count_override, build_dir, output_file, platform, browser, scale_unit=True, show_iteration_values=False, device_id=None):
         try:
             plan_file = self._find_plan_file(plan_file)
             with open(plan_file, 'r') as fp:
@@ -35,6 +35,8 @@ class BenchmarkRunner(object):
                     self._plan['local_copy'] = local_copy
                 if count_override:
                     self._plan['count'] = count_override
+                if timeout_factor:
+                    self._plan['timeout'] = self._plan['timeout'] * timeout_factor
                 self._browser_driver = BrowserDriverFactory.create(platform, browser)
                 self._build_dir = os.path.abspath(build_dir) if build_dir else None
                 self._output_file = output_file

--- a/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -15,10 +15,10 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, build_dir, output_file, platform, browser, scale_unit=True, show_iteration_values=False, device_id=None):
+    def __init__(self, plan_file, local_copy, timeout_factor, count_override, build_dir, output_file, platform, browser, scale_unit=True, show_iteration_values=False, device_id=None):
         self._http_server_driver = HTTPServerDriverFactory.create(platform)
         self._http_server_driver.set_device_id(device_id)
-        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, build_dir, output_file, platform, browser, scale_unit, show_iteration_values, device_id)
+        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, timeout_factor, count_override, build_dir, output_file, platform, browser, scale_unit, show_iteration_values, device_id)
 
     def _get_result(self, test_url):
         result = self._browser_driver.add_additional_results(test_url, self._http_server_driver.fetch_result())

--- a/webkitpy/browserperfdash/browserperfdash_runner.py
+++ b/webkitpy/browserperfdash/browserperfdash_runner.py
@@ -55,6 +55,7 @@ def parse_args():
     parser.add_argument('--driver', default=WebServerBenchmarkRunner.name, choices=benchmark_runner_subclasses.keys(), help='Use the specified benchmark driver. Defaults to %s.' % WebServerBenchmarkRunner.name)
     parser.add_argument('--local-copy', dest='localCopy', help='Path to a local copy of the benchmark. e.g. PerformanceTests/SunSpider/')
     parser.add_argument('--count', dest='countOverride', type=int, help='Number of times to run the benchmark. e.g. 5')
+    parser.add_argument('--timeout-factor', dest='timeoutFactorOverride', type=int, help='Timeout factor useful to run test in slower devices. e.g. 10')
     mutual_group = parser.add_mutually_exclusive_group(required=True)
     mutual_group.add_argument('--plan', dest='plan', help='Benchmark plan to run. e.g. speedometer, jetstream')
     mutual_group.add_argument('--allplans', action='store_true', help='Run all available benchmark plans sequentially')
@@ -169,7 +170,7 @@ class BrowserPerfDashRunner(object):
                 # Run test and save test info
                 with tempfile.NamedTemporaryFile() as temp_result_file:
                     benchmark_runner_class = benchmark_runner_subclasses[self._args.driver]
-                    runner = benchmark_runner_class(plan, self._args.localCopy, self._args.countOverride, self._args.buildDir, temp_result_file.name, self._args.platform, self._args.browser)
+                    runner = benchmark_runner_class(plan, self._args.localCopy, self._args.timeoutFactorOverride, self._args.countOverride, self._args.buildDir, temp_result_file.name, self._args.platform, self._args.browser)
                     runner.execute()
                     _log.info('Finished benchmark plan: {plan_name}'.format(plan_name=plan))
                     # Fill test info for upload

--- a/webkitpy/browserperfdash/browserperfdash_unittest.py
+++ b/webkitpy/browserperfdash/browserperfdash_unittest.py
@@ -40,8 +40,8 @@ _log = logging.getLogger(__name__)
 class FakeBenchmarkRunner(BenchmarkRunner):
     name = 'fake'
 
-    def __init__(self, plan_file, local_copy, count_override, build_dir, output_file, platform, browser):
-        super(FakeBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, build_dir, output_file, platform, browser)
+    def __init__(self, plan_file, local_copy, timeout_factor, count_override, build_dir, output_file, platform, browser):
+        super(FakeBenchmarkRunner, self).__init__(plan_file, local_copy, timeout_factor, count_override, build_dir, output_file, platform, browser)
 
     def execute(self):
         return True


### PR DESCRIPTION
The timeout-factor is useful to run the tests in slower devices where the default timeout value defined in the .plan files is not high enough to let the tests end.